### PR TITLE
add hardware acceleration support

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  # keep-sorted start
   adwaita-icon-theme,
   alsa-lib,
   autoPatchelfHook,
@@ -12,6 +13,7 @@
   hicolor-icon-theme,
   libXtst,
   libva,
+  mesa,
   makeBinaryWrapper,
   makeDesktopItem,
   patchelfUnstable,
@@ -19,6 +21,21 @@
   pipewire,
   wrapGAppsHook3,
   nix-update-script,
+  ffmpeg_7,
+  libGL,
+  libX11,
+  libXScrnSaver,
+  libpciaccess,
+  # Additional libraries for WebGL and GFX support
+  libffi,
+  libgcrypt,
+  libxcomposite,
+  libxdamage,
+  libxrandr,
+  libXt,
+  libevent,
+  # Ensure OpenGL and WebGL support
+  libGLU,
   ...
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -65,15 +82,35 @@ stdenv.mkDerivation (finalAttrs: {
     gtk3
     hicolor-icon-theme
     libXtst
+    libGL
+    libX11
+    libXScrnSaver
+    libpciaccess
+    ffmpeg_7
+    libffi
+    libgcrypt
+    libxcomposite
+    libxdamage
+    libxrandr
+    libXt
+    alsa-lib
+    libevent
+    mesa
+    libGLU
   ];
 
   runtimeDependencies = lib.optionals stdenv.isLinux [
     curl
     libva.out
+    mesa
     pciutils
+    libGL
   ];
 
-  appendRunpaths = lib.optionals stdenv.isLinux [ "${pipewire}/lib" ];
+  appendRunpaths = lib.optionals stdenv.isLinux [
+    "${pipewire}/lib"
+    "${libGL}/lib"
+  ];
 
   # Firefox uses "relrhack" to manually process relocations from a fixed offset
   patchelfFlags = lib.optionals stdenv.isLinux [ "--no-clobber-old-sections" ];
@@ -86,6 +123,10 @@ stdenv.mkDerivation (finalAttrs: {
     /usr/bin/hdiutil detach /Volumes/Glide
 
     runHook postUnpack
+  preFixup = lib.optionals stdenv.isLinux ''
+    gappsWrapperArgs+=(
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ ffmpeg_7 ]}"
+      )
   '';
 
   installPhase =
@@ -117,12 +158,16 @@ stdenv.mkDerivation (finalAttrs: {
         mkdir -p $out/Applications
         cp -r Glide.app $out/Applications/
 
-        mkdir -p $out/bin
-        ln -s $out/Applications/Glide.app/Contents/MacOS/glide $out/bin/glide
-        ln -s $out/bin/glide $out/bin/glide-browser
+    runHook postInstall
 
-        runHook postInstall
-      '';
+  # WebGL/Graphics settings via environment variables
+  shellHook = lib.optionals stdenv.isLinux ''
+    export MOZ_DISABLE_RDD_SANDBOX=1  # Disable RDD sandbox to prevent WebGL issues
+    export MOZ_WEBRENDER=1  # Enable WebRender for GPU acceleration
+    export MOZ_ACCELERATED=1  # Enable hardware acceleration for WebGL
+    export WebglAllowWindowsNativeGl=true  # Allow native GL for WebGL
+    export AllowWebgl2=true  # Enable WebGL2 support
+  '';
 
   desktopItems = [
     (makeDesktopItem {

--- a/package.nix
+++ b/package.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
     /usr/bin/hdiutil detach /Volumes/Glide
 
     runHook postUnpack
-    '';
+  '';
   preFixup = lib.optionals stdenv.isLinux ''
     gappsWrapperArgs+=(
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ ffmpeg_7 ]}"
@@ -159,7 +159,12 @@ stdenv.mkDerivation (finalAttrs: {
         mkdir -p $out/Applications
         cp -r Glide.app $out/Applications/
 
-    runHook postInstall
+        mkdir -p $out/bin
+        ln -s $out/Applications/Glide.app/Contents/MacOS/glide $out/bin/glide
+        ln -s $out/bin/glide $out/bin/glide-browser
+
+        runHook postInstall
+      '';
 
   # WebGL/Graphics settings via environment variables
   shellHook = lib.optionals stdenv.isLinux ''

--- a/package.nix
+++ b/package.nix
@@ -123,6 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
     /usr/bin/hdiutil detach /Volumes/Glide
 
     runHook postUnpack
+    '';
   preFixup = lib.optionals stdenv.isLinux ''
     gappsWrapperArgs+=(
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ ffmpeg_7 ]}"

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/mxf7g5ygry2sy88pxijbdrld0s5b11m2-glide-browser-0.1.56a

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/mxf7g5ygry2sy88pxijbdrld0s5b11m2-glide-browser-0.1.56a


### PR DESCRIPTION
This is based off of the work done in #1 by @idlip. I can't verify that the dependencies are as minimal as they should be unfortunately, as I'm not familiar enough with what all is necessary for hardware acceleration. I just wanted to clean up the fix so that this could be upstreamed easily

Proof compositing works (glide built using this package definition)
<img width="813" height="61" alt="image" src="https://github.com/user-attachments/assets/52f82f1e-705b-4a33-bce3-548eafbd4279" /> 
