### PR TITLE
Fix missing dependencies in Nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -89,10 +89,16 @@ stdenv.mkDerivation (finalAttrs: {
   # Firefox uses "relrhack" to manually process relocations from a fixed offset
   patchelfFlags = lib.optionals stdenv.isLinux [ "--no-clobber-old-sections" ];
 
-  # Add ffmpeg to LD_LIBRARY_PATH (mirroring Zen's approach) for media support
+  # 1. Add ffmpeg to LD_LIBRARY_PATH (mirroring Zen's approach) for media support
+  # 2. Set MOZ_LEGACY_PROFILES=1 to prevent creating new profiles on every update
+  # 3. Set MOZ_ALLOW_DOWNGRADE=1 to prevent errors if rolling back updates
   preFixup = lib.optionalString stdenv.isLinux ''
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ ffmpeg ]}"
+      --set MOZ_LEGACY_PROFILES 1
+      --set MOZ_ALLOW_DOWNGRADE 1
+      --add-flags "--name=glide-browser"
+      --add-flags "--class=glide-browser"
     )
   '';
 


### PR DESCRIPTION
Several dependencies were missing during Glide installation.
I took the ones from Zen browser.

This PR fixes WebGL and WebAuthn on NixOS.