### PR TITLE
correct binaryName to match actual executable name

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -23,7 +23,7 @@
 }:
 
 let
-  binaryName = "glide-browser";
+  binaryName = "glide";
 
   glidePolicies = (config.glide-browser.policies or { }) // policies;
 
@@ -106,8 +106,6 @@ stdenv.mkDerivation {
       ''
         mkdir -p $out/Applications
         mv Glide*.app "$out/Applications/${applicationName}.app"
-
-        ln -s "$out/Applications/${applicationName}.app/Contents/MacOS/glide" "$out/Applications/${applicationName}.app/Contents/MacOS/${binaryName}"
       ''
     else
       ''
@@ -149,6 +147,6 @@ stdenv.mkDerivation {
       "aarch64-darwin"
     ];
     maintainers = with lib.maintainers; [ pyrox0 ];
-    mainProgram = "glide-browser";
+    mainProgram = "glide";
   };
 }


### PR DESCRIPTION
The unwrapped package sets `binaryName = "glide-browser"` while the actual installed executables in `$out/lib/glide-browser-bin-${version}/` are named `glide` and `glide-bin`. This causes `wrapFirefox` to malfunction.

`wrapFirefox` uses `binaryName` to find and copy (instead of symlinking) the browser executables into the wrapper's output, which is needed because firefox resolves paths like `defaults/pref/autoconfig.js` relative to the real path of the running binary. If the binary is a symlink firefox follows it to the unwrapped store path where none of the wrapper generated files are present. This causes configuration files added by `wrapFirefox` to be ignored.