### PR TITLE
flake: remove home-manager import, don't reimport nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770818644,
-        "narHash": "sha256-DYS4jIRpRoKOzJjnR/QqEd/MlT4OZZpt8CrBLv+cjsE=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "0acbd1180697de56724821184ad2c3e6e7202cd7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770562336,
@@ -38,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
   in {
     packages = forAllSystems (system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = nixpkgs.legacyPackages.${system};
         glide = pkgs.callPackage ./package.nix { };
       in rec {
         glide-browser-bin-unwrapped = glide;

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  inputs.home-manager = {
-    url = "github:nix-community/home-manager";
-    inputs.nixpkgs.follows = "nixpkgs";
-  };
-
-  outputs = { self, home-manager, nixpkgs, ... }:
+  outputs = { self, nixpkgs, ... }:
   let
     systems = [
       "x86_64-linux"
@@ -36,7 +31,7 @@
 
     homeModules = {
       default = import ./hm-module {
-        inherit self home-manager;
+        inherit self;
       };
     };
 

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -1,11 +1,11 @@
 {
-  home-manager,
   self,
 }:
 {
   config,
   pkgs,
   lib,
+  modulesPath,
   ...
 }:
 let
@@ -19,7 +19,7 @@ let
     "glide-browser"
   ];
 
-  mkFirefoxModule = import "${home-manager.outPath}/modules/programs/firefox/mkFirefoxModule.nix";
+  mkFirefoxModule = import "${modulesPath}/modules/programs/firefox/mkFirefoxModule.nix";
 in
 {
   imports = [


### PR DESCRIPTION
`modulesPath` within the module system provides the same functionality as `home-manager.outPath`, but removes the input on the flake end. And `import nixpkgs` reimports nixpkgs, while using the `legacyPackages` approach is more performant and reuses the existing instance.