### PR TITLE
package: libXtst -> libxtst to remove alias usage

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -9,7 +9,7 @@
   curl,
   dbus-glib,
   gtk3,
-  libXtst,
+  libxtst,
   libva,
   pciutils,
   pipewire,
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
     adwaita-icon-theme
     alsa-lib
     dbus-glib
-    libXtst
+    libxtst
   ];
 
   runtimeDependencies = [


### PR DESCRIPTION
`libXtst` in Nixpkgs is an alias for `libxtst`. It does not warn, but using aliases is often not preferred and it can break configs which are using `config.allowAliases = false;`. While this is nonstandard, it seems that there's no harm in using the canonical name, so we might as well. Alias definition: https://github.com/NixOS/nixpkgs/blob/3431bb1194dd3c1a78b1f4d23cd3068ef83c5aef/pkgs/top-level/aliases.nix#L1291

Tested with `nix-build -E 'let pkgs = import <nixpkgs> { config.allowAliases = false; }; in pkgs.callPackage ./package.nix { }'`.